### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.proto linguist-language=Protocol-Buffer linguist-detectable
+*.bzl linguist-language=Starlark
+*.build linguist-language=Starlark
+*.owl linguist-language=Web-Ontology-Language


### PR DESCRIPTION
### Description

- Version: `1.9.0-alpha3`
- Filed By: @sgammon
- Linked Issue: `Bloombox/OpenCannabis#1`

Adds `.gitattributes` from upstream to fix Protocol Buffer language stats.